### PR TITLE
ci: fetch more tags less often

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,13 +11,13 @@ resources:
   - name: golang-img-tag
     type: registry-tag
     icon: tag
-    check_every: 15m
+    check_every: 60m
     source:
       uri: https://hub.docker.com/v2/repositories/library/golang
-      pages: 3
+      pages: 10
       regexp: '^[0-9]+[.][0-9]+[.][0-9]+-alpine'
       semver:
-        matcher: '>= 1.14'
+        matcher: '>= 1.16'
 
   - name: weather-exporter-src
     type: git


### PR DESCRIPTION
3 is not enough pages to always get an alpine tag